### PR TITLE
Retrograde to QtMultimedia 5.7 for debian stretch compatiblity

### DIFF
--- a/Main.qml
+++ b/Main.qml
@@ -1,6 +1,6 @@
 import QtQuick 2.0
 import SddmComponents 2.0
-import QtMultimedia 5.8
+import QtMultimedia 5.7
 
 import "components"
 


### PR DESCRIPTION
Debian stretch is at qt5.7.
There are no major changes related to this theme.

![image](https://user-images.githubusercontent.com/12765875/56852259-36713b00-6919-11e9-89ff-474526ee92e1.png)
5.8 changelog
