### PR TITLE
Improved gentoo instructions (probably) covering all requried dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,12 @@ It is necessary to have the Phonon GStreamer backend for qt5, GStreamer ffmpeg P
 - For Gentoo : these settings allowed me to make the theme work
 
     * `media-libs/gst-plugins-good`
-    * `USE="alsa gsteamer qml widgets" dev-qt/qtmultimedia`
+    * `USE="alsa gstreamer qml widgets" dev-qt/qtmultimedia`
+    * `USE="widgets" dev-qt/qtquickcontrols`
+    * `dev-qt/qtgraphicaleffects`
     * `USE="gstreamer" media-libs/phonon`
+    * `media-plugins/gst-plugins-openh264` (optional for video)
+    * `media-plugins/gst-plugins-libde265` (optional for video)
 
  - For Kubuntu: `apt install gstreamer1.0-libav phonon4qt5-backend-gstreamer gstreamer1.0-plugins-good qml-module-qtquick-controls qml-module-qtgraphicaleffects qml-module-qtmultimedia qt5-default`
 


### PR DESCRIPTION
Hello! My minimalistic setup didn't have as much packages as yours so had to mess around to get it working. Due to source code it should cover all dependencies excluding maybe images stuff (I hope people using sddm themes already have *something* installed)